### PR TITLE
Automate release badges and APK download links

### DIFF
--- a/.github/badges/update-date.json
+++ b/.github/badges/update-date.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "label": "更新日期",
+  "message": "2026-07-07",
+  "color": "blue",
+  "namedLogo": "githubactions",
+  "cacheSeconds": 3600
+}

--- a/.github/badges/version.json
+++ b/.github/badges/version.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "label": "最新版本",
+  "message": "V22.0",
+  "color": "brightgreen",
+  "namedLogo": "github",
+  "cacheSeconds": 3600
+}

--- a/.github/scripts/generate_apk_links.py
+++ b/.github/scripts/generate_apk_links.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Generate Server/links.md from APK files in the repository."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+from pathlib import Path
+from urllib.parse import quote
+
+REPOSITORY = "daxiaamu/oplusmutools"
+JSDELIVR_MAX_BYTES = 20_000_000
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--commit", default=os.environ.get("GITHUB_SHA"))
+    parser.add_argument("--root", type=Path, default=Path("Server"))
+    parser.add_argument("--output", type=Path, default=Path("Server/links.md"))
+    args = parser.parse_args()
+
+    if not args.commit:
+        parser.error("--commit or GITHUB_SHA is required")
+
+    commit = args.commit.strip()
+    apk_files = sorted(
+        (path for path in args.root.rglob("*") if path.is_file() and path.suffix.lower() == ".apk"),
+        key=lambda path: path.relative_to(args.root).as_posix().casefold(),
+    )
+    if not apk_files:
+        raise SystemExit("No APK files found under Server")
+
+    lines = [
+        "# APK 下载链接",
+        "",
+        "本文件由 GitHub Actions 自动生成。每次 `Server/**/*.apk` 发生变化时都会重新扫描。",
+        "",
+        f"所有地址固定到包含本次 APK 集合的提交 `{commit}`，不依赖分支。",
+        "",
+        "> CDN 属于第三方服务，缓存刷新时间和可用性不受本仓库控制。下载后建议核对 SHA-256。jsDelivr 的 GitHub CDN 默认不支持大于 20 MB 的单文件。",
+        "",
+    ]
+
+    for path in apk_files:
+        relative = path.relative_to(args.root).as_posix()
+        encoded = quote(relative, safe="/-_.~")
+        size = path.stat().st_size
+        size_mib = size / (1024 * 1024)
+        base_path = f"Server/{encoded}"
+
+        lines.extend(
+            [
+                f"## `{relative}`",
+                "",
+                f"- 文件大小：{size_mib:.2f} MiB",
+                f"- GitHub Raw：[下载](https://raw.githubusercontent.com/{REPOSITORY}/{commit}/{base_path})",
+            ]
+        )
+        if size <= JSDELIVR_MAX_BYTES:
+            lines.append(
+                f"- jsDelivr：[下载](https://cdn.jsdelivr.net/gh/{REPOSITORY}@{commit}/{base_path})"
+            )
+        else:
+            lines.append("- jsDelivr：不可用（文件超过其 GitHub CDN 默认 20 MB 限制）")
+
+        lines.extend(
+            [
+                f"- Statically：[下载](https://cdn.statically.io/gh/{REPOSITORY}@{commit}/{base_path})",
+                f"- StaticDelivr：[下载](https://cdn.staticdelivr.com/gh/{REPOSITORY}/{commit}/{base_path})",
+                f"- GitHack：[下载](https://rawcdn.githack.com/{REPOSITORY}/{commit}/{base_path})",
+                f"- SHA-256：`{sha256(path)}`",
+                "",
+            ]
+        )
+
+    lines.extend(
+        [
+            "## CDN 地址规则",
+            "",
+            f"- GitHub Raw：`https://raw.githubusercontent.com/{REPOSITORY}/{commit}/Server/文件路径`",
+            f"- jsDelivr：`https://cdn.jsdelivr.net/gh/{REPOSITORY}@{commit}/Server/文件路径`",
+            f"- Statically：`https://cdn.statically.io/gh/{REPOSITORY}@{commit}/Server/文件路径`",
+            f"- StaticDelivr：`https://cdn.staticdelivr.com/gh/{REPOSITORY}/{commit}/Server/文件路径`",
+            f"- GitHack：`https://rawcdn.githack.com/{REPOSITORY}/{commit}/Server/文件路径`",
+            "",
+        ]
+    )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8", newline="\n") as stream:
+        stream.write("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/update-apk-links.yml
+++ b/.github/workflows/update-apk-links.yml
@@ -1,0 +1,48 @@
+name: Update APK download links
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "Server/**/*.apk"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: apk-download-links
+  cancel-in-progress: true
+
+jobs:
+  update-links:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out default branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Generate APK links
+        shell: bash
+        run: |
+          set -euo pipefail
+          python .github/scripts/generate_apk_links.py --commit "$(git rev-parse HEAD)"
+
+      - name: Commit updated links
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$(git status --porcelain -- Server/links.md)" ]]; then
+            echo "APK download links are already up to date."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Server/links.md
+          git commit -m "chore: update APK download links"
+          git push

--- a/.github/workflows/update-release-badges.yml
+++ b/.github/workflows/update-release-badges.yml
@@ -1,0 +1,88 @@
+name: Update release badges
+
+on:
+  release:
+    types:
+      - published
+      - edited
+  schedule:
+    - cron: "43 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-badges
+  cancel-in-progress: false
+
+jobs:
+  update-badges:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out default branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Read latest release and generate badges
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          release="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest")"
+          version="$(jq -r '.tag_name' <<< "${release}")"
+          update_date="$(jq -r '.published_at[0:10]' <<< "${release}")"
+
+          if [[ -z "${version}" || "${version}" == "null" ]]; then
+            echo "Latest release has no tag name."
+            exit 1
+          fi
+
+          if [[ ! "${update_date}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+            echo "Latest release has an invalid published date: ${update_date}"
+            exit 1
+          fi
+
+          mkdir -p .github/badges
+
+          jq -n \
+            --arg message "${version}" \
+            '{
+              schemaVersion: 1,
+              label: "最新版本",
+              message: $message,
+              color: "brightgreen",
+              namedLogo: "github",
+              cacheSeconds: 3600
+            }' > .github/badges/version.json
+
+          jq -n \
+            --arg message "${update_date}" \
+            '{
+              schemaVersion: 1,
+              label: "更新日期",
+              message: $message,
+              color: "blue",
+              namedLogo: "githubactions",
+              cacheSeconds: 3600
+            }' > .github/badges/update-date.json
+
+      - name: Commit updated badges
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$(git status --porcelain -- .github/badges)" ]]; then
+            echo "Release badges are already up to date."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/badges/version.json .github/badges/update-date.json
+          git commit -m "chore: update release badges"
+          git push

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 <p align="center">
 
   <img src="https://img.shields.io/badge/平台-Windows-blue" alt="平台">
+  <a href="https://github.com/daxiaamu/oplusmutools/releases/latest"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdaxiaamu%2Foplusmutools%2Fmain%2F.github%2Fbadges%2Fversion.json" alt="最新版本"></a>
+  <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdaxiaamu%2Foplusmutools%2Fmain%2F.github%2Fbadges%2Fupdate-date.json" alt="更新日期">
 </p>
 
 <div align="center">

--- a/Server/links.md
+++ b/Server/links.md
@@ -1,112 +1,125 @@
 # APK 下载链接
 
-本页汇总 `Server` 目录中各 APK 的下载地址。建议优先使用 GitHub Raw；访问较慢时再尝试其他 CDN。所有地址均固定到包含这批 APK 的提交 `7d2a0ec0180b497a9bcef6c3c34544bd5f724816`，不依赖 `main` 或临时分支。
+本文件由 GitHub Actions 自动生成。每次 `Server/**/*.apk` 发生变化时都会重新扫描。
 
-> CDN 属于第三方服务，缓存刷新时间和可用性不受本仓库控制。APK 更新后请核对文件名和 SHA-256。jsDelivr 的 GitHub CDN 默认不支持大于 20 MB 的单文件，因此未给 `Kitsune-Revived/30700.apk` 提供 jsDelivr 链接。
+所有地址固定到包含本次 APK 集合的提交 `2235905db3d97008639105fa5aeebfb6ee2fff86`，不依赖分支。
 
-## Alpha 30700
+> CDN 属于第三方服务，缓存刷新时间和可用性不受本仓库控制。下载后建议核对 SHA-256。jsDelivr 的 GitHub CDN 默认不支持大于 20 MB 的单文件。
 
-- 文件：`Alpha/e8a58776-alpha_30700.apk`（11.04 MiB）
-- GitHub Raw：[下载](https://raw.githubusercontent.com/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/Alpha/e8a58776-alpha_30700.apk)
-- jsDelivr：[下载](https://cdn.jsdelivr.net/gh/daxiaamu/oplusmutools@7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/Alpha/e8a58776-alpha_30700.apk)
-- Statically：[下载](https://cdn.statically.io/gh/daxiaamu/oplusmutools@7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/Alpha/e8a58776-alpha_30700.apk)
-- StaticDelivr：[下载](https://cdn.staticdelivr.com/gh/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/Alpha/e8a58776-alpha_30700.apk)
-- GitHack：[下载](https://rawcdn.githack.com/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/Alpha/e8a58776-alpha_30700.apk)
+## `Alpha/e8a58776-alpha_30700.apk`
+
+- 文件大小：11.04 MiB
+- GitHub Raw：[下载](https://raw.githubusercontent.com/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/Alpha/e8a58776-alpha_30700.apk)
+- jsDelivr：[下载](https://cdn.jsdelivr.net/gh/daxiaamu/oplusmutools@2235905db3d97008639105fa5aeebfb6ee2fff86/Server/Alpha/e8a58776-alpha_30700.apk)
+- Statically：[下载](https://cdn.statically.io/gh/daxiaamu/oplusmutools@2235905db3d97008639105fa5aeebfb6ee2fff86/Server/Alpha/e8a58776-alpha_30700.apk)
+- StaticDelivr：[下载](https://cdn.staticdelivr.com/gh/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/Alpha/e8a58776-alpha_30700.apk)
+- GitHack：[下载](https://rawcdn.githack.com/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/Alpha/e8a58776-alpha_30700.apk)
 - SHA-256：`e3cd39e1b8cef250841fa42b6a42d049c1b2f283cc93f55ecc90f1307c981d0b`
 
-## APatch 11219
+## `apatch/APatch_11219_0355948_HEAD-release-signed.apk`
 
-- 文件：`apatch/APatch_11219_0355948_HEAD-release-signed.apk`（5.12 MiB）
-- GitHub Raw：[下载](https://raw.githubusercontent.com/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/apatch/APatch_11219_0355948_HEAD-release-signed.apk)
-- jsDelivr：[下载](https://cdn.jsdelivr.net/gh/daxiaamu/oplusmutools@7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/apatch/APatch_11219_0355948_HEAD-release-signed.apk)
-- Statically：[下载](https://cdn.statically.io/gh/daxiaamu/oplusmutools@7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/apatch/APatch_11219_0355948_HEAD-release-signed.apk)
-- StaticDelivr：[下载](https://cdn.staticdelivr.com/gh/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/apatch/APatch_11219_0355948_HEAD-release-signed.apk)
-- GitHack：[下载](https://rawcdn.githack.com/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/apatch/APatch_11219_0355948_HEAD-release-signed.apk)
+- 文件大小：5.12 MiB
+- GitHub Raw：[下载](https://raw.githubusercontent.com/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/apatch/APatch_11219_0355948_HEAD-release-signed.apk)
+- jsDelivr：[下载](https://cdn.jsdelivr.net/gh/daxiaamu/oplusmutools@2235905db3d97008639105fa5aeebfb6ee2fff86/Server/apatch/APatch_11219_0355948_HEAD-release-signed.apk)
+- Statically：[下载](https://cdn.statically.io/gh/daxiaamu/oplusmutools@2235905db3d97008639105fa5aeebfb6ee2fff86/Server/apatch/APatch_11219_0355948_HEAD-release-signed.apk)
+- StaticDelivr：[下载](https://cdn.staticdelivr.com/gh/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/apatch/APatch_11219_0355948_HEAD-release-signed.apk)
+- GitHack：[下载](https://rawcdn.githack.com/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/apatch/APatch_11219_0355948_HEAD-release-signed.apk)
 - SHA-256：`cadc957b2c76ac28bcb351cd09d12c48cb32d2848eac4596b04e8fb0fe72f501`
 
-## EdXposed Manager
+## `apatch/APatch_11224_9a63e0f_HEAD-release-signed.apk`
 
-- 文件：`edxposed/edxposedmanager.apk`（3.39 MiB）
-- GitHub Raw：[下载](https://raw.githubusercontent.com/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/edxposed/edxposedmanager.apk)
-- jsDelivr：[下载](https://cdn.jsdelivr.net/gh/daxiaamu/oplusmutools@7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/edxposed/edxposedmanager.apk)
-- Statically：[下载](https://cdn.statically.io/gh/daxiaamu/oplusmutools@7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/edxposed/edxposedmanager.apk)
-- StaticDelivr：[下载](https://cdn.staticdelivr.com/gh/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/edxposed/edxposedmanager.apk)
-- GitHack：[下载](https://rawcdn.githack.com/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/edxposed/edxposedmanager.apk)
+- 文件大小：6.26 MiB
+- GitHub Raw：[下载](https://raw.githubusercontent.com/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/apatch/APatch_11224_9a63e0f_HEAD-release-signed.apk)
+- jsDelivr：[下载](https://cdn.jsdelivr.net/gh/daxiaamu/oplusmutools@2235905db3d97008639105fa5aeebfb6ee2fff86/Server/apatch/APatch_11224_9a63e0f_HEAD-release-signed.apk)
+- Statically：[下载](https://cdn.statically.io/gh/daxiaamu/oplusmutools@2235905db3d97008639105fa5aeebfb6ee2fff86/Server/apatch/APatch_11224_9a63e0f_HEAD-release-signed.apk)
+- StaticDelivr：[下载](https://cdn.staticdelivr.com/gh/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/apatch/APatch_11224_9a63e0f_HEAD-release-signed.apk)
+- GitHack：[下载](https://rawcdn.githack.com/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/apatch/APatch_11224_9a63e0f_HEAD-release-signed.apk)
+- SHA-256：`f1986f9a9c3b2b2d5ca09aa6b9ef24226fef662f8faf5677ce1447ffcae68590`
+
+## `edxposed/edxposedmanager.apk`
+
+- 文件大小：3.39 MiB
+- GitHub Raw：[下载](https://raw.githubusercontent.com/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/edxposed/edxposedmanager.apk)
+- jsDelivr：[下载](https://cdn.jsdelivr.net/gh/daxiaamu/oplusmutools@2235905db3d97008639105fa5aeebfb6ee2fff86/Server/edxposed/edxposedmanager.apk)
+- Statically：[下载](https://cdn.statically.io/gh/daxiaamu/oplusmutools@2235905db3d97008639105fa5aeebfb6ee2fff86/Server/edxposed/edxposedmanager.apk)
+- StaticDelivr：[下载](https://cdn.staticdelivr.com/gh/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/edxposed/edxposedmanager.apk)
+- GitHack：[下载](https://rawcdn.githack.com/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/edxposed/edxposedmanager.apk)
 - SHA-256：`bcb72143828260db1da312a510897f426c434261b9903e23053b4dae562d8534`
 
-## KernelSU 3.2.5
+## `kernelsu/KernelSU_v3.2.5_32525-release.apk`
 
-- 文件：`kernelsu/KernelSU_v3.2.5_32525-release.apk`（8.66 MiB）
-- GitHub Raw：[下载](https://raw.githubusercontent.com/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/kernelsu/KernelSU_v3.2.5_32525-release.apk)
-- jsDelivr：[下载](https://cdn.jsdelivr.net/gh/daxiaamu/oplusmutools@7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/kernelsu/KernelSU_v3.2.5_32525-release.apk)
-- Statically：[下载](https://cdn.statically.io/gh/daxiaamu/oplusmutools@7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/kernelsu/KernelSU_v3.2.5_32525-release.apk)
-- StaticDelivr：[下载](https://cdn.staticdelivr.com/gh/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/kernelsu/KernelSU_v3.2.5_32525-release.apk)
-- GitHack：[下载](https://rawcdn.githack.com/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/kernelsu/KernelSU_v3.2.5_32525-release.apk)
+- 文件大小：8.66 MiB
+- GitHub Raw：[下载](https://raw.githubusercontent.com/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/kernelsu/KernelSU_v3.2.5_32525-release.apk)
+- jsDelivr：[下载](https://cdn.jsdelivr.net/gh/daxiaamu/oplusmutools@2235905db3d97008639105fa5aeebfb6ee2fff86/Server/kernelsu/KernelSU_v3.2.5_32525-release.apk)
+- Statically：[下载](https://cdn.statically.io/gh/daxiaamu/oplusmutools@2235905db3d97008639105fa5aeebfb6ee2fff86/Server/kernelsu/KernelSU_v3.2.5_32525-release.apk)
+- StaticDelivr：[下载](https://cdn.staticdelivr.com/gh/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/kernelsu/KernelSU_v3.2.5_32525-release.apk)
+- GitHack：[下载](https://rawcdn.githack.com/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/kernelsu/KernelSU_v3.2.5_32525-release.apk)
 - SHA-256：`1417081413bf7ab1de8e440ecbcb62685037c8f28f048f0f8b79e305b31ab916`
 
-## KernelSU Next 3.3.0
+## `kernelsunext/KernelSU_Next_v3.3.0_33214-release.apk`
 
-- 文件：`kernelsunext/KernelSU_Next_v3.3.0_33214-release.apk`（9.74 MiB）
-- GitHub Raw：[下载](https://raw.githubusercontent.com/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/kernelsunext/KernelSU_Next_v3.3.0_33214-release.apk)
-- jsDelivr：[下载](https://cdn.jsdelivr.net/gh/daxiaamu/oplusmutools@7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/kernelsunext/KernelSU_Next_v3.3.0_33214-release.apk)
-- Statically：[下载](https://cdn.statically.io/gh/daxiaamu/oplusmutools@7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/kernelsunext/KernelSU_Next_v3.3.0_33214-release.apk)
-- StaticDelivr：[下载](https://cdn.staticdelivr.com/gh/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/kernelsunext/KernelSU_Next_v3.3.0_33214-release.apk)
-- GitHack：[下载](https://rawcdn.githack.com/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/kernelsunext/KernelSU_Next_v3.3.0_33214-release.apk)
+- 文件大小：9.74 MiB
+- GitHub Raw：[下载](https://raw.githubusercontent.com/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/kernelsunext/KernelSU_Next_v3.3.0_33214-release.apk)
+- jsDelivr：[下载](https://cdn.jsdelivr.net/gh/daxiaamu/oplusmutools@2235905db3d97008639105fa5aeebfb6ee2fff86/Server/kernelsunext/KernelSU_Next_v3.3.0_33214-release.apk)
+- Statically：[下载](https://cdn.statically.io/gh/daxiaamu/oplusmutools@2235905db3d97008639105fa5aeebfb6ee2fff86/Server/kernelsunext/KernelSU_Next_v3.3.0_33214-release.apk)
+- StaticDelivr：[下载](https://cdn.staticdelivr.com/gh/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/kernelsunext/KernelSU_Next_v3.3.0_33214-release.apk)
+- GitHack：[下载](https://rawcdn.githack.com/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/kernelsunext/KernelSU_Next_v3.3.0_33214-release.apk)
 - SHA-256：`fd0b12385c98fe9d5f4f1257b5f184e55c74c1376637507df0718305f5d7a924`
 
-## Kitsune 27.2
+## `Kitsune-Revived/30700.apk`
 
-- 文件：`Kitsune/v27.2-kitsune-4.apk`（12.18 MiB）
-- GitHub Raw：[下载](https://raw.githubusercontent.com/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/Kitsune/v27.2-kitsune-4.apk)
-- jsDelivr：[下载](https://cdn.jsdelivr.net/gh/daxiaamu/oplusmutools@7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/Kitsune/v27.2-kitsune-4.apk)
-- Statically：[下载](https://cdn.statically.io/gh/daxiaamu/oplusmutools@7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/Kitsune/v27.2-kitsune-4.apk)
-- StaticDelivr：[下载](https://cdn.staticdelivr.com/gh/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/Kitsune/v27.2-kitsune-4.apk)
-- GitHack：[下载](https://rawcdn.githack.com/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/Kitsune/v27.2-kitsune-4.apk)
-- SHA-256：`818cfa02783ddae573cc953450fbc39ec3e5164b66e517c657ba11cf90963a89`
-
-## Kitsune Revived 30700
-
-- 文件：`Kitsune-Revived/30700.apk`（20.06 MiB）
-- GitHub Raw：[下载](https://raw.githubusercontent.com/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/Kitsune-Revived/30700.apk)
-- Statically：[下载](https://cdn.statically.io/gh/daxiaamu/oplusmutools@7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/Kitsune-Revived/30700.apk)
-- StaticDelivr：[下载](https://cdn.staticdelivr.com/gh/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/Kitsune-Revived/30700.apk)
-- GitHack：[下载](https://rawcdn.githack.com/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/Kitsune-Revived/30700.apk)
+- 文件大小：20.06 MiB
+- GitHub Raw：[下载](https://raw.githubusercontent.com/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/Kitsune-Revived/30700.apk)
+- jsDelivr：不可用（文件超过其 GitHub CDN 默认 20 MB 限制）
+- Statically：[下载](https://cdn.statically.io/gh/daxiaamu/oplusmutools@2235905db3d97008639105fa5aeebfb6ee2fff86/Server/Kitsune-Revived/30700.apk)
+- StaticDelivr：[下载](https://cdn.staticdelivr.com/gh/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/Kitsune-Revived/30700.apk)
+- GitHack：[下载](https://rawcdn.githack.com/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/Kitsune-Revived/30700.apk)
 - SHA-256：`18a0f7b96a930bcc26ba705073ab0436df7c4e26ec4b01a678655435f9776a9f`
 
-## Magisk 30700
+## `Kitsune/v27.2-kitsune-4.apk`
 
-- 文件：`magisk/magisk30700.apk`（11.08 MiB）
-- GitHub Raw：[下载](https://raw.githubusercontent.com/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/magisk/magisk30700.apk)
-- jsDelivr：[下载](https://cdn.jsdelivr.net/gh/daxiaamu/oplusmutools@7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/magisk/magisk30700.apk)
-- Statically：[下载](https://cdn.statically.io/gh/daxiaamu/oplusmutools@7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/magisk/magisk30700.apk)
-- StaticDelivr：[下载](https://cdn.staticdelivr.com/gh/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/magisk/magisk30700.apk)
-- GitHack：[下载](https://rawcdn.githack.com/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/magisk/magisk30700.apk)
+- 文件大小：12.18 MiB
+- GitHub Raw：[下载](https://raw.githubusercontent.com/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/Kitsune/v27.2-kitsune-4.apk)
+- jsDelivr：[下载](https://cdn.jsdelivr.net/gh/daxiaamu/oplusmutools@2235905db3d97008639105fa5aeebfb6ee2fff86/Server/Kitsune/v27.2-kitsune-4.apk)
+- Statically：[下载](https://cdn.statically.io/gh/daxiaamu/oplusmutools@2235905db3d97008639105fa5aeebfb6ee2fff86/Server/Kitsune/v27.2-kitsune-4.apk)
+- StaticDelivr：[下载](https://cdn.staticdelivr.com/gh/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/Kitsune/v27.2-kitsune-4.apk)
+- GitHack：[下载](https://rawcdn.githack.com/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/Kitsune/v27.2-kitsune-4.apk)
+- SHA-256：`818cfa02783ddae573cc953450fbc39ec3e5164b66e517c657ba11cf90963a89`
+
+## `magisk/magisk30700.apk`
+
+- 文件大小：11.08 MiB
+- GitHub Raw：[下载](https://raw.githubusercontent.com/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/magisk/magisk30700.apk)
+- jsDelivr：[下载](https://cdn.jsdelivr.net/gh/daxiaamu/oplusmutools@2235905db3d97008639105fa5aeebfb6ee2fff86/Server/magisk/magisk30700.apk)
+- Statically：[下载](https://cdn.statically.io/gh/daxiaamu/oplusmutools@2235905db3d97008639105fa5aeebfb6ee2fff86/Server/magisk/magisk30700.apk)
+- StaticDelivr：[下载](https://cdn.staticdelivr.com/gh/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/magisk/magisk30700.apk)
+- GitHack：[下载](https://rawcdn.githack.com/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/magisk/magisk30700.apk)
 - SHA-256：`e0d32d2123532860f97123d927b1bb86c4e08e6fd8a48bfc6b5bee0afae9ebd5`
 
-## ReSukiSU 4.1.0 (35006)
+## `resukisu/ReSukiSU_v4.1.0_35006-arm64-v8a-release.apk`
 
-- 文件：`resukisu/ReSukiSU_v4.1.0_35006-arm64-v8a-release.apk`（8.05 MiB）
-- GitHub Raw：[下载](https://raw.githubusercontent.com/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/resukisu/ReSukiSU_v4.1.0_35006-arm64-v8a-release.apk)
-- jsDelivr：[下载](https://cdn.jsdelivr.net/gh/daxiaamu/oplusmutools@7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/resukisu/ReSukiSU_v4.1.0_35006-arm64-v8a-release.apk)
-- Statically：[下载](https://cdn.statically.io/gh/daxiaamu/oplusmutools@7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/resukisu/ReSukiSU_v4.1.0_35006-arm64-v8a-release.apk)
-- StaticDelivr：[下载](https://cdn.staticdelivr.com/gh/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/resukisu/ReSukiSU_v4.1.0_35006-arm64-v8a-release.apk)
-- GitHack：[下载](https://rawcdn.githack.com/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/resukisu/ReSukiSU_v4.1.0_35006-arm64-v8a-release.apk)
+- 文件大小：8.05 MiB
+- GitHub Raw：[下载](https://raw.githubusercontent.com/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/resukisu/ReSukiSU_v4.1.0_35006-arm64-v8a-release.apk)
+- jsDelivr：[下载](https://cdn.jsdelivr.net/gh/daxiaamu/oplusmutools@2235905db3d97008639105fa5aeebfb6ee2fff86/Server/resukisu/ReSukiSU_v4.1.0_35006-arm64-v8a-release.apk)
+- Statically：[下载](https://cdn.statically.io/gh/daxiaamu/oplusmutools@2235905db3d97008639105fa5aeebfb6ee2fff86/Server/resukisu/ReSukiSU_v4.1.0_35006-arm64-v8a-release.apk)
+- StaticDelivr：[下载](https://cdn.staticdelivr.com/gh/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/resukisu/ReSukiSU_v4.1.0_35006-arm64-v8a-release.apk)
+- GitHack：[下载](https://rawcdn.githack.com/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/resukisu/ReSukiSU_v4.1.0_35006-arm64-v8a-release.apk)
 - SHA-256：`d06db332f733b38c3381fa95151af6c3c94e409d5c27b3dc2b5219c88353c848`
 
-## SukiSU Ultra 4.1.3
+## `sukisu-ultra/SukiSU_v4.1.3_40796-release.apk`
 
-- 文件：`sukisu-ultra/SukiSU_v4.1.3_40796-release.apk`（11.59 MiB）
-- GitHub Raw：[下载](https://raw.githubusercontent.com/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/sukisu-ultra/SukiSU_v4.1.3_40796-release.apk)
-- jsDelivr：[下载](https://cdn.jsdelivr.net/gh/daxiaamu/oplusmutools@7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/sukisu-ultra/SukiSU_v4.1.3_40796-release.apk)
-- Statically：[下载](https://cdn.statically.io/gh/daxiaamu/oplusmutools@7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/sukisu-ultra/SukiSU_v4.1.3_40796-release.apk)
-- StaticDelivr：[下载](https://cdn.staticdelivr.com/gh/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/sukisu-ultra/SukiSU_v4.1.3_40796-release.apk)
-- GitHack：[下载](https://rawcdn.githack.com/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/sukisu-ultra/SukiSU_v4.1.3_40796-release.apk)
+- 文件大小：11.59 MiB
+- GitHub Raw：[下载](https://raw.githubusercontent.com/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/sukisu-ultra/SukiSU_v4.1.3_40796-release.apk)
+- jsDelivr：[下载](https://cdn.jsdelivr.net/gh/daxiaamu/oplusmutools@2235905db3d97008639105fa5aeebfb6ee2fff86/Server/sukisu-ultra/SukiSU_v4.1.3_40796-release.apk)
+- Statically：[下载](https://cdn.statically.io/gh/daxiaamu/oplusmutools@2235905db3d97008639105fa5aeebfb6ee2fff86/Server/sukisu-ultra/SukiSU_v4.1.3_40796-release.apk)
+- StaticDelivr：[下载](https://cdn.staticdelivr.com/gh/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/sukisu-ultra/SukiSU_v4.1.3_40796-release.apk)
+- GitHack：[下载](https://rawcdn.githack.com/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/sukisu-ultra/SukiSU_v4.1.3_40796-release.apk)
 - SHA-256：`1b1e837c0a5b6aa34554882fad67cef6db6ca1a84d43e07dd904cf54f8d261ae`
 
 ## CDN 地址规则
 
-- GitHub Raw：`https://raw.githubusercontent.com/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/文件路径`
-- jsDelivr：`https://cdn.jsdelivr.net/gh/daxiaamu/oplusmutools@7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/文件路径`
-- Statically：`https://cdn.statically.io/gh/daxiaamu/oplusmutools@7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/文件路径`
-- StaticDelivr：`https://cdn.staticdelivr.com/gh/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/文件路径`
-- GitHack：`https://rawcdn.githack.com/daxiaamu/oplusmutools/7d2a0ec0180b497a9bcef6c3c34544bd5f724816/Server/文件路径`
+- GitHub Raw：`https://raw.githubusercontent.com/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/文件路径`
+- jsDelivr：`https://cdn.jsdelivr.net/gh/daxiaamu/oplusmutools@2235905db3d97008639105fa5aeebfb6ee2fff86/Server/文件路径`
+- Statically：`https://cdn.statically.io/gh/daxiaamu/oplusmutools@2235905db3d97008639105fa5aeebfb6ee2fff86/Server/文件路径`
+- StaticDelivr：`https://cdn.staticdelivr.com/gh/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/文件路径`
+- GitHack：`https://rawcdn.githack.com/daxiaamu/oplusmutools/2235905db3d97008639105fa5aeebfb6ee2fff86/Server/文件路径`


### PR DESCRIPTION
## 变更内容

- README 增加“最新版本”和“更新日期”徽章
- 新增 Shields Endpoint JSON 数据文件
- 发布或编辑 Release 时自动读取最新正式 Release：
  - 版本来自 `tag_name`
  - 更新日期来自 `published_at`
- 每天北京时间约 09:43 兜底检查一次，并支持手动运行
- `Server/**/*.apk` 在 `main` 有新增、替换或删除时，自动重新生成 `Server/links.md`
- 链接固定到 APK 变更提交 SHA，不依赖分支
- 自动计算文件大小、SHA-256，并生成 GitHub Raw、jsDelivr、Statically、StaticDelivr、GitHack 地址
- 超过 jsDelivr 20 MB 默认限制的 APK 自动跳过该来源

## 当前初始化数据

- 最新正式 Release：`V22.0`
- Release 更新日期：`2026-07-07`
- 当前 APK 数量：11
- 已包含新文件 `APatch_11224_9a63e0f_HEAD-release-signed.apk`

## 校验

- 两个 GitHub Actions YAML 均已通过解析
- APK 链接生成器已实际运行
- 生成结果与提交的 `Server/links.md` 完全一致
- 11 个 APK 均包含对应 SHA-256
